### PR TITLE
6.8 jest tests

### DIFF
--- a/packages/client/src/components/organisms/Game/utils/FireShot.test.ts
+++ b/packages/client/src/components/organisms/Game/utils/FireShot.test.ts
@@ -1,0 +1,51 @@
+import { Store } from '../core/Store'
+import { fireShot } from './FireShot'
+
+describe('Game engine basics', () => {
+  test('creates game with 10x10 boards', () => {
+    const store = new Store()
+    const state = store.getState()
+
+    expect(state.playerBoard).toHaveLength(10)
+    expect(state.playerBoard[0]).toHaveLength(10)
+    expect(state.enemyBoard).toHaveLength(10)
+    expect(state.enemyBoard[0]).toHaveLength(10)
+  })
+
+  test('returns hit for ship cell', () => {
+    const board = Array.from({ length: 10 }, () =>
+      Array(10).fill('empty' as const)
+    )
+    board[2][3] = 'ship'
+
+    const result = fireShot({ x: 3, y: 2 }, board)
+
+    expect(result.result).toBe('hit')
+    expect(result.board[2][3]).toBe('hited')
+  })
+
+  test('returns miss for empty cell', () => {
+    const board = Array.from({ length: 10 }, () =>
+      Array(10).fill('empty' as const)
+    )
+
+    const result = fireShot({ x: 1, y: 1 }, board)
+
+    expect(result.result).toBe('miss')
+    expect(result.board[1][1]).toBe('miss')
+  })
+
+  test('prevents repeated shot to the same cell', () => {
+    const board = Array.from({ length: 10 }, () =>
+      Array(10).fill('empty' as const)
+    )
+    board[4][4] = 'ship'
+
+    const firstShot = fireShot({ x: 4, y: 4 }, board)
+    const secondShot = fireShot({ x: 4, y: 4 }, firstShot.board)
+
+    expect(firstShot.result).toBe('hit')
+    expect(secondShot.result).toBe('null')
+    expect(secondShot.board[4][4]).toBe('hited')
+  })
+})

--- a/packages/client/src/organisms/Header/Header.test.tsx
+++ b/packages/client/src/organisms/Header/Header.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import Header from './Header'
+
+describe('Header UI', () => {
+  test('renders main navigation link', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('link', { name: 'Main' })).toBeTruthy()
+  })
+
+  test('handles click on Game link', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    )
+
+    const gameLink = screen.getByRole('link', { name: 'Game' })
+    fireEvent.click(gameLink)
+
+    expect(gameLink.getAttribute('href')).toBe('/game')
+  })
+})


### PR DESCRIPTION
Добавлены тесты для игры "Морской бой". 
- Покрыта базовая бизнес-логика выстрелов (инициализация поля, попадание, промах, повторный выстрел) 
- Протестирован UI-компонент (Header: рендер ссылки и клик по ссылке Game). 

Тесты написаны на Jest + RTL.